### PR TITLE
jpeg-recompress-bin 0.1.5 fixes Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "exec-buffer": "^0.1.1",
     "image-type": "^0.1.4",
     "tempfile": "^0.1.3",
-    "jpeg-recompress-bin": "^0.1.4"
+    "jpeg-recompress-bin": "^0.1.5"
   },
   "devDependencies": {
     "imagemin": "^0.4.6",
@@ -47,6 +47,6 @@
     "mocha": "^1.20.1",
     "q": "^2.0.1",
     "rimraf": "^2.2.8",
-    "traceur": "0.0.43"
+    "traceur": "0.0.44"
   }
 }


### PR DESCRIPTION
As per https://github.com/1000ch/node-jpeg-recompress-bin/pull/5
